### PR TITLE
fix: Enable auto-upgrade in beta clusters with a release channel (#682)

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -72,7 +72,12 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
+{% if beta_cluster %}
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
+{% else %}
   default_auto_upgrade = var.regional ? true : false
+{% endif %}
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}


### PR DESCRIPTION
* Enable auto-upgrade in beta clusters with a release channel

Without this setting, a cluster with a default node pool will fail when
a release channel is specified. The API responds with:

Error: error creating NodePool: googleapi: Error 400: Auto_upgrade cannot be false when release_channel REGULAR is set., badRequest

This is noted in the documentation, that use of a release channel
requires auto-upgrade and auto-repair to be enabled:

https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels#new-cluster

* Only include comment in beta block, run make build

The previous location I placed the comment meant that it was in place
even in non-beta clusters, so the comment was describing behavior that
wasn't actually in place.

Co-authored-by: Bharath KKB <bharathkrishnakb@gmail.com>