### PR TITLE
fix: Updating the Binary Authorization submodule to allow Terraform 0…

### DIFF
--- a/modules/binary-authorization/main.tf
+++ b/modules/binary-authorization/main.tf
@@ -25,7 +25,7 @@ locals {
 
 module "project-services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 8.0"
+  version = "~> 9.2.0"
 
   project_id    = var.project_id
   activate_apis = local.required_enabled_apis


### PR DESCRIPTION
….13 (#726)